### PR TITLE
Update quickstart Stateful Arpeggiator section

### DIFF
--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -273,7 +273,7 @@ return pattern {
 }
 ```
 - TRY THIS: Add direction changes: `if index >= #notes or index <= 1 then direction = direction * -1 end`
-- TRY THIS: Change notes based on time: `notes = scale("C4", {"major","minor"}[math.floor(context.pulse_time) % 2 + 1]).notes`
+- TRY THIS: Create notes from a random scale: `local notes = scale("c4", ({"major","minor"})[math.random(2)]).notes`
 
 This example demonstrates stateful emitters that remember their position between calls, enabling sequences and other time-dependent behaviors.
 

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -273,7 +273,7 @@ return pattern {
 }
 ```
 - TRY THIS: Add direction changes: `if index >= #notes or index <= 1 then direction = direction * -1 end`
-- TRY THIS: Change notes based on time: `notes = scale("C4", {"major","minor"}[math.floor(context.time) % 2 + 1])`.notes
+- TRY THIS: Change notes based on time: `notes = scale("C4", {"major","minor"}[math.floor(context.pulse_time) % 2 + 1]).notes`
 
 This example demonstrates stateful emitters that remember their position between calls, enabling sequences and other time-dependent behaviors.
 


### PR DESCRIPTION
Correct an example snippet. context.time isn't valid, I believe context.pulse_time is intended here. Also moved the `.notes` bit inside the code formatting. Ran into this while learning, very fun tool!